### PR TITLE
Remove extended modifiers

### DIFF
--- a/Text/Wiki/Parse/Default/Anchor.php
+++ b/Text/Wiki/Parse/Default/Anchor.php
@@ -49,7 +49,7 @@ class Text_Wiki_Parse_Anchor extends Text_Wiki_Parse {
                         '(\[\[\#\s)' .             # Two brackets, then hash
                         '([-_A-Za-z0-9.%]+?)' .   # Contents of anchor
                         '(\]\])' .                # Closing brackets
-                        '/ix';
+                        '/i';
 
     /**
      *

--- a/Text/Wiki/Parse/Default/Bibcite.php
+++ b/Text/Wiki/Parse/Default/Bibcite.php
@@ -48,7 +48,7 @@ class Text_Wiki_Parse_Bibcite extends Text_Wiki_Parse {
                         'bibcite\s' .        # Module name and whitespace
                         '([a-z0-9]+)' .      # Alphanumeric citation
                         '\)\)' .             # Closing parens
-                        '/ix';
+                        '/i';
 
     function process(&$matches) {
         $label = $matches[1];

--- a/Text/Wiki/Parse/Default/Bibliography.php
+++ b/Text/Wiki/Parse/Default/Bibliography.php
@@ -41,7 +41,7 @@ class Text_Wiki_Parse_Bibliography extends Text_Wiki_Parse {
                     '(.*?)' .                     # Contents
                     '\[\[\/bibliography\]\]' .    # End tag
                     '[\s]*$' .                    # Allow whitespace until end of the line
-                    '/smx';
+                    '/sm';
         $this->wiki->source = preg_replace_callback($regex,
             array(&$this, 'process'), $this->wiki->source, 1);
     }

--- a/Text/Wiki/Parse/Default/Blockquote.php
+++ b/Text/Wiki/Parse/Default/Blockquote.php
@@ -55,7 +55,7 @@ class Text_Wiki_Parse_Blockquote extends Text_Wiki_Parse {
                         '\n' .            # Start at a newline
                         '((\>).*?\n)' .   # Match a >, then anything up until a newline
                         '(?!(\>))' .      # Assert that the newline is not followed by a >
-                        '/sx';
+                        '/s';
      # Sorry, what? A line of blockquote //cannot// be followed by another
      # line? Am I reading that correctly? Then why is the second > captured?
      # ANSWER: This module doesn't even use this regex. Nice one, Wikidot.
@@ -98,7 +98,7 @@ class Text_Wiki_Parse_Blockquote extends Text_Wiki_Parse {
             '(\>+?)' .    # At least one >
             '\s' .        # Require exactly one whitespace
             '(.*?\n)' .   # Include anything else up until a newline
-            '/msx',
+            '/ms',
             $matches[1],
             $list,
             PREG_SET_ORDER

--- a/Text/Wiki/Parse/Default/Bold.php
+++ b/Text/Wiki/Parse/Default/Bold.php
@@ -57,7 +57,7 @@ class Text_Wiki_Parse_Bold extends Text_Wiki_Parse {
                         "()" .              # Nothing (captured, for some reason)
                         "|[^'].*?)" .       # OR any text that doesn't start with a single quote
                         "'''" .             # Closing triple single-quotes
-                        "/x";
+                        "/";
 
     /**
     *

--- a/Text/Wiki/Parse/Default/Button.php
+++ b/Text/Wiki/Parse/Default/Button.php
@@ -34,7 +34,7 @@ class Text_Wiki_Parse_Button extends Text_Wiki_Parse {
                         '([a-z0-9\-_]+)' .   # Button name
                         '(?:\s+(.+?))?' .    # Optional button parameters
                         '\]\]' .             # Closing brackets
-                        '/isx';
+                        '/is';
 
     function process(&$matches)
     {

--- a/Text/Wiki/Parse/Default/Clearfloat.php
+++ b/Text/Wiki/Parse/Default/Clearfloat.php
@@ -48,7 +48,7 @@ class Text_Wiki_Parse_Clearfloat extends Text_Wiki_Parse {
                         '([~]{4,})' .   # ~~~~
                         '(>|<)?' .      # Optional directional modifier
                         '$' . 
-                        '/mx';
+                        '/m';
 
     /**
      *

--- a/Text/Wiki/Parse/Default/Collapsible.php
+++ b/Text/Wiki/Parse/Default/Collapsible.php
@@ -51,7 +51,7 @@ class Text_Wiki_Parse_Collapsible extends Text_Wiki_Parse {
                         '\]\]' . 
                         '(.*?)' .          # Contents of collapsible - no nesting
                         '\[\[\/collapsible\]\]\s*' . 
-                        '/msix';
+                        '/msi';
 
     /**
      *

--- a/Text/Wiki/Parse/Default/Colortext.php
+++ b/Text/Wiki/Parse/Default/Colortext.php
@@ -48,12 +48,12 @@ class Text_Wiki_Parse_Colortext extends Text_Wiki_Parse {
      */
 
     public $regex =     '/' . 
-                        '\#\#' . 
+                        '##' . 
                         '(.+?)' .   # Colou?r
                         '\|' .      # Pipe to split colour and text
                         '(.+?)' .   # Text
-                        '\#\#' . 
-                        '/x';
+                        '##' . 
+                        '/';
 
     /**
      *

--- a/Text/Wiki/Parse/Default/Comment.php
+++ b/Text/Wiki/Parse/Default/Comment.php
@@ -46,7 +46,7 @@ class Text_Wiki_Parse_Comment extends Text_Wiki_Parse {
                         '\[!\-\-' .   # [!--
                         '(.*?)' .     # Any text - no nesting
                         '\-\-\]' .    # --]
-                        '/six';
+                        '/si';
 
     /**
      *

--- a/Text/Wiki/Parse/Default/Date.php
+++ b/Text/Wiki/Parse/Default/Date.php
@@ -32,7 +32,7 @@ class Text_Wiki_Parse_Date extends Text_Wiki_Parse {
                         '([0-9]+)' .      # A number, for a given time. Required.
                         '(\s+.*?)?' .     # Optional extra parameters (format)
                         '\]\]' . 
-                        '/x';
+                        '/';
     /**
     *
     * Generates a token entry for the matched text.  Token options are:

--- a/Text/Wiki/Parse/Default/Deflist.php
+++ b/Text/Wiki/Parse/Default/Deflist.php
@@ -58,7 +58,7 @@ class Text_Wiki_Parse_Deflist extends Text_Wiki_Parse {
                     '\n' . 
                     '((:\s).*?\n)' .    # Match colon, whitespace, then text up to newline
                     '(?!(:\s|\n))' .    # Do not match if followed by colon+ws or newline
-                    '/sx';
+                    '/s';
 
     /**
     *

--- a/Text/Wiki/Parse/Default/Divalign.php
+++ b/Text/Wiki/Parse/Default/Divalign.php
@@ -46,7 +46,7 @@ class Text_Wiki_Parse_Divalign extends Text_Wiki_Parse {
                         '((?:(?R)|.)*?)' .       # Contents of tag - nesting is allowed
                         '\[\[\/\\1\]\]' .        # Closing tag that matches opening tag
                         '$' .                    # End of line
-                        '/msix';
+                        '/msi';
 
     /**
      *

--- a/Text/Wiki/Parse/Default/Divprefilter.php
+++ b/Text/Wiki/Parse/Default/Divprefilter.php
@@ -46,7 +46,7 @@ class Text_Wiki_Parse_Divprefilter extends Text_Wiki_Parse {
                         '\[\[\/div\]\]' . 
                         '(\s*?)' . 
                         '\[\[div' . 
-                        '/msix';
+                        '/msi';
     /**
     *
     * Generates a token entry for the matched text.  Token options are:

--- a/Text/Wiki/Parse/Default/Email.php
+++ b/Text/Wiki/Parse/Default/Email.php
@@ -49,7 +49,7 @@ class Text_Wiki_Parse_Email extends Text_Wiki_Parse {
     function parse(){
 
     	 	// described emails
-        $tmp_regex = '/\[(' . $this->regex . ') (.+?)\]/ix';
+        $tmp_regex = '/\[(' . $this->regex . ')\s(.+?)\]/i';
         $this->wiki->source = preg_replace_callback(
             $tmp_regex,
             array(&$this, 'processDescr'),
@@ -57,7 +57,7 @@ class Text_Wiki_Parse_Email extends Text_Wiki_Parse {
         );
 
     		// standalone emails
-        $tmp_regex = '/' . $this->regex . '/ix';
+        $tmp_regex = '/' . $this->regex . '/i';
         $this->wiki->source = preg_replace_callback(
             $tmp_regex,
             array(&$this, 'process'),

--- a/Text/Wiki/Parse/Default/Embed.php
+++ b/Text/Wiki/Parse/Default/Embed.php
@@ -42,7 +42,7 @@ class Text_Wiki_Parse_Embed extends Text_Wiki_Parse {
                         '\[\[embed(?:audio|video)?\]\]' . 
                         '(.*?)' . 
                         '\[\[\/embed(?:audio|video)?\]\]' . 
-                        '/msix';
+                        '/msi';
     /**
     *
     * Generates a token entry for the matched text.  Token options are:

--- a/Text/Wiki/Parse/Default/Emphasis.php
+++ b/Text/Wiki/Parse/Default/Emphasis.php
@@ -57,7 +57,7 @@ class Text_Wiki_Parse_Emphasis extends Text_Wiki_Parse {
                         "(?:.*?[^\s])?" .       # Anything that does not end in whitespace
                         ")" . 
                         "\/\/" .                # //
-                        "/x";
+                        "/";
 
     /**
     *

--- a/Text/Wiki/Parse/Default/Equationreference.php
+++ b/Text/Wiki/Parse/Default/Equationreference.php
@@ -43,8 +43,8 @@ class Text_Wiki_Parse_Equationreference extends Text_Wiki_Parse {
     */
 
     public $regex =     '/' . 
-                        '\[\[eref (.*?)\]\]' . 
-                        '/x';
+                        '\[\[eref\s(.*?)\]\]' . 
+                        '/';
     /**
     *
     * Generates a token entry for the matched text.  Token options are:

--- a/Text/Wiki/Parse/Default/File.php
+++ b/Text/Wiki/Parse/Default/File.php
@@ -44,7 +44,7 @@ class Text_Wiki_Parse_File extends Text_Wiki_Parse {
                         '(.+?)' .          # Name of file
                         '(?:\|(.+?))?' .   # Pipe, then link text (optional)
                         '\]\]' . 
-                        '/ix';
+                        '/i';
 
     function process(&$matches)
     {

--- a/Text/Wiki/Parse/Default/Footnote.php
+++ b/Text/Wiki/Parse/Default/Footnote.php
@@ -46,7 +46,7 @@ class Text_Wiki_Parse_Footnote extends Text_Wiki_Parse {
                         '\[\[footnote\]\]' . 
                         '(.*?)' . 
                         '\[\[\/footnote\]\]' . 
-                        '/sx';
+                        '/s';
 
     function process(&$matches)
     {

--- a/Text/Wiki/Parse/Default/Form.php
+++ b/Text/Wiki/Parse/Default/Form.php
@@ -49,7 +49,7 @@ class Text_Wiki_Parse_Form extends Text_Wiki_Parse {
                         '---\s*\n' .             # Three hyphens (???)
                         '(.*)\n' .               # Anything again
                         '\[\[\/form\]\]' . 
-                        '/isx';
+                        '/is';
 
     /**
      *

--- a/Text/Wiki/Parse/Default/Freelink.php
+++ b/Text/Wiki/Parse/Default/Freelink.php
@@ -59,7 +59,7 @@ class Text_Wiki_Parse_Freelink extends Text_Wiki_Parse {
                         ')?' .                      # Link text is optional
                         '()' .                      # Are you kidding me
                         '\]\]\]' .                  # Closing brackets
-                        '/x';
+                        '/';
 
     /**
     *

--- a/Text/Wiki/Parse/Default/Function.php
+++ b/Text/Wiki/Parse/Default/Function.php
@@ -36,7 +36,7 @@ class Text_Wiki_Parse_Function extends Text_Wiki_Parse {
                         '(.+?)\n' . 
                         '(\<\/function\>)' . 
                         '(\s|$)' . 
-                        '/msix';
+                        '/msi';
 
     function process(&$matches)
     {

--- a/Text/Wiki/Parse/Default/Gallery.php
+++ b/Text/Wiki/Parse/Default/Gallery.php
@@ -45,7 +45,7 @@ class Text_Wiki_Parse_Gallery extends Text_Wiki_Parse {
                         '\[\[gallery(\s[^\]]*?)?\]\]' . 
                         '(?:((?:\n:\s[^\n]+)+)\n' . 
                         '\[\[\/gallery\]\])?' . 
-                        '/msix';
+                        '/msi';
 
     /**
      *

--- a/Text/Wiki/Parse/Default/Html.php
+++ b/Text/Wiki/Parse/Default/Html.php
@@ -53,7 +53,7 @@ class Text_Wiki_Parse_Html extends Text_Wiki_Parse {
                         '(.+?)\n' . 
                         '\<\/html\>' . 
                         '(\s|$)' . 
-                        '/msix';
+                        '/msi';
 
     /**
     *

--- a/Text/Wiki/Parse/Default/Iftags.php
+++ b/Text/Wiki/Parse/Default/Iftags.php
@@ -32,7 +32,7 @@ class Text_Wiki_Parse_Iftags extends Text_Wiki_Parse {
         				'(?:(?R)|.)' . 	            		# Contents of the page, including other iftags
         				'*?)' .                        		# Non-greedy match to claim next closing tag
         				'\[\[\/iftags\]\]' .            	# Closing tag
-        				'/msix';
+        				'/msi';
     # Note regarding non-greedy match: I'm not sure how a recursive regex match
     # works entirely, so I've written that it claims the next closing tag.
     # That's unlikely to be true and definitely not intended behaviour.

--- a/Text/Wiki/Parse/Default/Image.php
+++ b/Text/Wiki/Parse/Default/Image.php
@@ -64,7 +64,7 @@ class Text_Wiki_Parse_Image extends Text_Wiki_Parse {
                         '(?:\]\])' .              # End opening image tag
                         '(?:(.*?)' .              # Capture any text inside the image element
                         '\[\[\/image\]\])?' .     # Allow end tag. Content + end tag is not required
-                        '/isx';
+                        '/is';
 
     /**
      * The regular expressions used to check ecternal urls

--- a/Text/Wiki/Parse/Default/Include.php
+++ b/Text/Wiki/Parse/Default/Include.php
@@ -66,7 +66,7 @@ class Text_Wiki_Parse_Include extends Text_Wiki_Parse {
         				'([a-zA-Z0-9\s\-:]+?)' .    # Name or location of component
         				'(\s+.*?)?' .               # Parameters
         				'(?:\]\])$' .               # Match but not capture closing tags? Ok
-        				'/imsx';
+        				'/ims';
 
  	function parse(){
  		$level = 0;

--- a/Text/Wiki/Parse/Default/Italic.php
+++ b/Text/Wiki/Parse/Default/Italic.php
@@ -50,7 +50,7 @@ class Text_Wiki_Parse_Italic extends Text_Wiki_Parse {
 
     public $regex =     "/" . 
                         "''(()|[^'].*)''" . 
-                        "/x";
+                        "/";
 
     /**
     *

--- a/Text/Wiki/Parse/Default/Math.php
+++ b/Text/Wiki/Parse/Default/Math.php
@@ -55,7 +55,7 @@ class Text_Wiki_Parse_Math extends Text_Wiki_Parse {
                         '((?:(?R)|.)*?)\n' .        # Contents - nesting is ok for some reason
                         '\[\[\/math\]\]' .          # Closing tag
                         '(\s|$)' . 
-                        '/msix';
+                        '/msi';
 
     /**
     *

--- a/Text/Wiki/Parse/Default/Mathinline.php
+++ b/Text/Wiki/Parse/Default/Mathinline.php
@@ -48,7 +48,7 @@ class Text_Wiki_Parse_Mathinline extends Text_Wiki_Parse {
                         '(.*?)' .   # Contents
                         '\$' .      # $
                         '\]\]' . 
-                        '/x';
+                        '/';
     /**
     *
     * Generates a token entry for the matched text.  Token options are:

--- a/Text/Wiki/Parse/Default/Module.php
+++ b/Text/Wiki/Parse/Default/Module.php
@@ -53,7 +53,7 @@ class Text_Wiki_Parse_Module extends Text_Wiki_Parse {
                             '(.*?)' .             # Content betweent tags - no nesting
                             '\[\[\/module\]\]' .  # Closing tag
                         ')?' .                    # The content and end tag is optional
-                        '/ismx';
+                        '/ism';
 
     /**
      *
@@ -94,7 +94,7 @@ class Text_Wiki_Parse_Module extends Text_Wiki_Parse {
                             '([a-z0-9_\-\/]+)' .      # Module name, alphanumeric + some chars
                             '(\s+.*?)?' .             # Optional module parameters
                             '\]\]' .                  # End opening tag
-                            '/smix', $con, $dummy) > 1) {
+                            '/smi', $con, $dummy) > 1) {
             return preg_replace('/^\[\[module/', '[[module654', $con);
         }
 

--- a/Text/Wiki/Parse/Default/Modulepre.php
+++ b/Text/Wiki/Parse/Default/Modulepre.php
@@ -52,7 +52,7 @@ class Text_Wiki_Parse_Modulepre extends Text_Wiki_Parse {
                             '(.*?)' .             # Content betweent tags - no nesting
                             '\[\[\/module\]\]' .  # Closing tag
                         ')?' .                    # The content and end tag is optional
-                        '/ismx';
+                        '/ism';
 
     /**
      *

--- a/Text/Wiki/Parse/Default/Newline.php
+++ b/Text/Wiki/Parse/Default/Newline.php
@@ -52,7 +52,7 @@ class Text_Wiki_Parse_Newline extends Text_Wiki_Parse {
                         '([^\n])' .   # Match any character that is not a newline
                         '\n' .        # Then a newline
                         '(?!\n)' .    # ...so long as it is not followed by another newline
-                        '/mx';
+                        '/m';
 
     /**
     *

--- a/Text/Wiki/Parse/Default/Note.php
+++ b/Text/Wiki/Parse/Default/Note.php
@@ -45,7 +45,7 @@ class Text_Wiki_Parse_Note extends Text_Wiki_Parse {
                         '\[\[note\]\]\n' . 
                         '(.*?)' .             # Contents of note - no nesting
                         '\[\[\/note\]\]' . 
-                        '/msix';
+                        '/msi';
 
     /**
      *

--- a/Text/Wiki/Parse/Default/Paragraph.php
+++ b/Text/Wiki/Parse/Default/Paragraph.php
@@ -54,7 +54,7 @@ class Text_Wiki_Parse_Paragraph extends Text_Wiki_Parse {
                     '\n' .     # A newline
                     '\s*?' .   # Any amount of whitespace, including none
                     '\n' .     # A further newline
-                    '/mx';
+                    '/m';
 
     public $conf = array(
         'skip' => array('blockquote', // are we sure about this one?

--- a/Text/Wiki/Parse/Default/Raw.php
+++ b/Text/Wiki/Parse/Default/Raw.php
@@ -52,7 +52,7 @@ class Text_Wiki_Parse_Raw extends Text_Wiki_Parse {
                         '@@' . 
                         '(.*?[^@]?)' .   # Match anything, up to a @
                         '@@' . 
-                        '/x';
+                        '/';
 
     /**
      *

--- a/Text/Wiki/Parse/Default/Revise.php
+++ b/Text/Wiki/Parse/Default/Revise.php
@@ -47,7 +47,7 @@ class Text_Wiki_Parse_Revise extends Text_Wiki_Parse {
                         '\@\@' . 
                         '(\{*?.*?\}*?)' .   # Text between any number of braces, including none
                         '\@\@' . 
-                        '/x';
+                        '/';
 
     /**
     *

--- a/Text/Wiki/Parse/Default/Separator.php
+++ b/Text/Wiki/Parse/Default/Separator.php
@@ -50,7 +50,7 @@ class Text_Wiki_Parse_Separator extends Text_Wiki_Parse {
                         '^' . 
                         '([=]{4,})' . 	# "====", four or more =
                         '$' . 
-                        '/mx';
+                        '/m';
 
     /**
     *

--- a/Text/Wiki/Parse/Default/Size.php
+++ b/Text/Wiki/Parse/Default/Size.php
@@ -43,7 +43,7 @@ class Text_Wiki_Parse_Size extends Text_Wiki_Parse {
                         '\[\[size\s([^\]]+)\]\]' .   # Opening tag including parameters
                         '((?:(?R)|.)*?)' .           # Any content in between including other sizes
                         '\[\[\/size\]\]' .           # Closing tag
-                        '/msix';
+                        '/msi';
     /**
     *
     * Generates a token entry for the matched text.  Token options are:

--- a/Text/Wiki/Parse/Default/Social.php
+++ b/Text/Wiki/Parse/Default/Social.php
@@ -44,7 +44,7 @@ class Text_Wiki_Parse_Social extends Text_Wiki_Parse {
                         '\[\[social' . 
                         '(\s+[^\]]+?)?' .   # Parameters
                         '\]\]' . 
-                        '/isx';
+                        '/is';
 
     function process(&$matches)
     {

--- a/Text/Wiki/Parse/Default/Span.php
+++ b/Text/Wiki/Parse/Default/Span.php
@@ -46,7 +46,7 @@ class Text_Wiki_Parse_Span extends Text_Wiki_Parse {
                         '\]\]' . 
                         '((?:(?R)|.)*?)' .   # Contents - nesting is ok
                         '\[\[\/span\]\]' . 
-                        '/msix';
+                        '/msi';
 
     /**
      *

--- a/Text/Wiki/Parse/Default/Strikethrough.php
+++ b/Text/Wiki/Parse/Default/Strikethrough.php
@@ -47,7 +47,7 @@ class Text_Wiki_Parse_Strikethrough extends Text_Wiki_Parse {
                         '\-\-' . 
                         '([^\s](?:.*?[^\s])?)' .   # Match anything that does not start or end with whitespace
                         '\-\-' . 
-                        '/x';
+                        '/';
 
     /**
      *

--- a/Text/Wiki/Parse/Default/Strong.php
+++ b/Text/Wiki/Parse/Default/Strong.php
@@ -55,7 +55,7 @@ class Text_Wiki_Parse_Strong extends Text_Wiki_Parse {
                         '\*\*' . 
                         '([^\s\n](?:.*?[^\s\n])?)' .   # Match anything that does not start or end with whitespace
                         '\*\*' . 
-                        '/x';
+                        '/';
 
     /**
      *

--- a/Text/Wiki/Parse/Default/Subscript.php
+++ b/Text/Wiki/Parse/Default/Subscript.php
@@ -49,7 +49,7 @@ class Text_Wiki_Parse_Subscript extends Text_Wiki_Parse {
                     ',,' . 
                     '([^\s](?:.*?[^\s])?)' .   # Match anything that does not start or end with whitespace
                     ',,' . 
-                    '/x';
+                    '/';
 
     /**
      *

--- a/Text/Wiki/Parse/Default/Superscript.php
+++ b/Text/Wiki/Parse/Default/Superscript.php
@@ -49,7 +49,7 @@ class Text_Wiki_Parse_Superscript extends Text_Wiki_Parse {
                         '\^\^' . 
                         '([^\s](?:.*?[^\s])?)' .   # Match anything that does not start or end with whitespace
                         '\^\^' . 
-                        '/x';
+                        '/';
 
     /**
     *

--- a/Text/Wiki/Parse/Default/Table.php
+++ b/Text/Wiki/Parse/Default/Table.php
@@ -57,7 +57,7 @@ class Text_Wiki_Parse_Table extends Text_Wiki_Parse {
                         ')' . 
                         '(\n)' .         # Newline
                         '(?!(\|\|))' .   # Assert that the newline is not followed by ||
-                        '/sx';
+                        '/s';
 
     /**
     *

--- a/Text/Wiki/Parse/Default/Tabview.php
+++ b/Text/Wiki/Parse/Default/Tabview.php
@@ -53,7 +53,7 @@ class Text_Wiki_Parse_Tabview extends Text_Wiki_Parse {
                             ')+' .                             # Require at least one tab
                         ')' . 
                         '\[\[\/(?:tabview|tabs)\]\]\s*' .      # Tabview closing tag
-                        '/msix';
+                        '/msi';
 
     private $_startTabToken;
     private $_endTabToken;
@@ -101,7 +101,7 @@ class Text_Wiki_Parse_Tabview extends Text_Wiki_Parse {
                                             '\]\]' . 
                                             '(.*?)' .              # Contents of tab - cannot contain [[tab]]
                                             '\[\[\/tab\]\]\n*' .   # Tab closing tag
-                                            '/msix',
+                                            '/msi',
             array($this, '_handleTab'), $content);
 
         $options = array('args' => $args, 'type' => 'start',
@@ -139,7 +139,7 @@ class Text_Wiki_Parse_Tabview extends Text_Wiki_Parse {
                         '=' . 
                         '"[^"]+"' .          # Parameter value in quotes
                         '$' .                # End of text
-                        '/six',
+                        '/si',
             trim($matches[1]))) {
                 $argString .= ' ' . $matches[1];
                 $ff = true;

--- a/Text/Wiki/Parse/Default/Toc.php
+++ b/Text/Wiki/Parse/Default/Toc.php
@@ -58,7 +58,7 @@ class Text_Wiki_Parse_Toc extends Text_Wiki_Parse {
                         '(\s.*)?' .    # Parameters
                         '\]\]' . 
                         '(\n)*' .      # Allow any number of newlines
-                        '/mx';
+                        '/m';
     # The newlines capture may interfere with a [[newlines]] module
 
     /**

--- a/Text/Wiki/Parse/Default/Tt.php
+++ b/Text/Wiki/Parse/Default/Tt.php
@@ -57,7 +57,7 @@ class Text_Wiki_Parse_Tt extends Text_Wiki_Parse {
                         '\{\{' . 
                         '(\{*?.*?\}*?)' .   # Allows }, then text, then }. Sorry, what?
                         '\}\}' . 
-                        '/x';
+                        '/';
 
     /**
     *

--- a/Text/Wiki/Parse/Default/Underline.php
+++ b/Text/Wiki/Parse/Default/Underline.php
@@ -55,7 +55,7 @@ class Text_Wiki_Parse_Underline extends Text_Wiki_Parse {
                         '__' . 
                         '([^\s](?:.*?[^\s])?)' .   # Match anything so long as it does not start or end with whitespace
                         '__' . 
-                        '/x';
+                        '/';
 
     /**
      *

--- a/Text/Wiki/Parse/Default/Url.php
+++ b/Text/Wiki/Parse/Default/Url.php
@@ -151,7 +151,7 @@ class Text_Wiki_Parse_Url extends Text_Wiki_Parse {
                         "(?:\/[^\s\t\n\"'".$this->wiki->delim."]*)" . 
                         ")\s" . 
                         "([^\]".$this->wiki->delim."]+)\]" . 
-                        "/x";
+                        "/";
 
         // use a custom callback processing method to generate
         // the replacement text for matches.
@@ -178,7 +178,7 @@ class Text_Wiki_Parse_Url extends Text_Wiki_Parse {
                             '\s' .             # A whitespace
                             '([^\]]+)' .       # Match anything up until a closing bracket
                             '\]' . 
-                            '/x';
+                            '/';
             $this->wiki->source = preg_replace_callback(
                 $tmp_regex,
                 array(&$this, 'processPV'),
@@ -198,7 +198,7 @@ class Text_Wiki_Parse_Url extends Text_Wiki_Parse {
                         '(\*)?' .                      # Any amount of asterisks
                         '(' . $this->regex . ')' . 
                         '(.*?)' .                      # Then anything, but as few as possible?
-                        '/x';
+                        '/';
 
         // use the standard callback for inline URLs
         $this->wiki->source = preg_replace_callback(

--- a/Text/Wiki/Parse/Default/User.php
+++ b/Text/Wiki/Parse/Default/User.php
@@ -44,7 +44,7 @@ class Text_Wiki_Parse_User extends Text_Wiki_Parse {
                         'user\s' . 
                         '([^\]]+)' .   # Parameters (e.g. user name)
                         '\]\]' . 
-                        '/ix';
+                        '/i';
 
     function process(&$matches) {
         $userName = $matches[2];


### PR DESCRIPTION
This allows `#` to go unescaped and also allows the space character, though that's probably poor practice anyway